### PR TITLE
Create-add-on 번역 추가

### DIFF
--- a/content/create-an-addon/react/ko/add-to-catalog.md
+++ b/content/create-an-addon/react/ko/add-to-catalog.md
@@ -1,0 +1,116 @@
+---
+title: '애드온 목록에 추가하기'
+tocTitle: '목록에 추가하세요'
+description: '커뮤니티에 스토리북 애드온을 공유해보세요'
+---
+
+[애드온 목록](https://storybook.js.org/addons)은 모든 스토리북 애드온의 메인화면 입니다. 애드온 개발자가 새로운 애드온을 발견하면 게시하는 페이지라고 생각하면 됩니다. 애드온 배포를 준비를 해서 패키지화 하고 목록에 출시해보세요.
+
+![](../../images/catalog.png)
+
+## 애드온 배포를 위한 준비
+
+자바스크립트 생태계의 대부분의 패키지와 같이 스토리북 애드온은 npm을 통해 배포할 수 있습니다. 하지만 이에 대해 특정한 기준이 있습니다:
+
+1. 트랜스파일된 ES5 코드가 포함된 dist 폴더를 가지고 있어야 합니다.
+2. ES5 모듈로 작성한 `preset.js`파일이 최상위 단계에 있어야 합니다.
+3. `package.json`파일이 다음을 선언해야 합니다:
+   - Peer-dependencies
+   - 모듈과 관련 정보
+   - 목록의 메타데이터
+
+애드온 키트는 개발자를 위해 이 부분을 대신 처리해줍니다. 개발자는 단순히 적절한 메타데이터만 제공하면 됩니다.
+
+## 모듈 메타데이터
+
+첫번째 목록은 메타데이터와 관련된 모듈입니다. 이것은 모듈의 주입구점(main entry point)과 애드온을 게재할 때 포함할 파일, 애드온의 모든 peer-dependency 파일들로 구성되어 있습니다. 예를 들어, 리액트와 리액트돔 등과 스토리북과 관련된 모든 API들이 해당됩니다.
+
+```json:title=package.json
+{
+  ...
+  "main": "dist/preset.js",
+  "files": [
+    "dist/**/*",
+    "README.md",
+    "*.js"
+  ],
+  "peerDependencies": {
+    "@storybook/addons": "^6.1.14",
+    "@storybook/api": "^6.1.14",
+    "@storybook/components": "^6.1.14",
+    "@storybook/core-events": "^6.1.14",
+    "@storybook/theming": "^6.1.14",
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
+  },
+  ...
+}
+```
+
+#### 왜 peer-dependencies 일까요?
+
+리액트에서 작동하는 라이브러리를 구축한다고 가정해 보세요. 리액트를 종속성 파일(dependency)에 포함하면 리액트 코드는 라이브러리와 함께 패키지화 됩니다. 라이브러리를 설치하는 사람들은 이미 코드 내에 리액트를 설치한 상태입니다. 다른 버전을 실행시키면 앱이 중단됩니다. 애드온도 같은 원리도 동작합니다.
+
+## 목록 메타데이터
+
+모듈과 관련된 정보에 따라 스토리북 애드온 목록에 대한 메타데이터를 지정해주어야 합니다.
+
+![목록 메타데이터는 태그, 호환성, 저자 등의 정보를 포함합니다.](../../images/catalog-metadata.png)
+
+이러한 정보 중 일부는 애드온 키트에 미리 구성되어 있습니다. 표시되는 이름, 아이콘 혹은 프레임워크 호환성과 같은 항목은 스토리북 속성을 통해 지정할 수 있습니다. 메타데이터의 전반적인 사양은 [애드온 메타데이터 문서](https://storybook.js.org/docs/react/addons/addon-catalog/#addon-metadata)를 참고해주세요.
+
+```json:title=package.json
+{
+  ...
+  "name": "my-storybook-addon",
+  "version": "1.0.0",
+  "description": "My first storybook addon",
+  "author": "Your Name",
+  "storybook": {
+    "displayName": "My Storybook Addon",
+    "unsupportedFrameworks": ["react-native"],
+    "icon": "https://yoursite.com/link-to-your-icon.png"
+  },
+  "keywords": ["storybook-addons", "appearance", "style", "css", "layout", "debug"]
+  ...
+}
+```
+
+여기서 키워드 속성은 목록의 태그에 대응도비니다. 예를 들어, 스토리북 애드온 태그는 애드온이 목록에 포함되도록 합니다. appearance는 최상위 단계 목록입니다. 나머지는 애드온의 검색기능에 도움을 주는 역할을 합니다.
+
+## NPM에 출시하기
+
+마지막 단계는 애드온을 실제로 출시하는 일입니다. 애드온 키트는 배포 관리를 위해 사전에 [Auto](https://github.com/intuit/auto) 패키지로 구성되어 있습니다. 변경로그를 만들고 깃허브와 npm에 push 해보세요. 즉, 두 가지 모두에 대해 접근권한을 설정해야 합니다.
+
+1. [npm adduser](https://docs.npmjs.com/cli/adduser.html)를 사용해 인증해주세요
+2. [액세스 토큰](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens)을 생성해보세요. _읽기와 쓰기_ 권한이 모두 있는 토큰이 필요합니다.
+3. 마찬가지로 [깃허브 토큰](https://github.com/settings/tokens)을 생성해보세요. 이 토큰에는 레포지토리 범위가 필요합니다.
+4. 프로젝트 최상위 위치에 `.env`파일을 생성하고, 다음 토큰을 모두 추가해주세요:
+
+```bash
+GH_TOKEN=깃허브에서 받아오는 토큰
+NPM_TOKEN=npm에서 받아오는 토큰
+```
+
+다음으로, **깃허브에서 라벨을 생성해보세요**. 나중에 패키지를 변경할 때 이 라벨을 사용하게 됩니다.
+
+```bash
+npx auto create-labels
+```
+
+깃허브를 확인해보면, Auto 패키지에서 사용할 수 있는 라벨의 목록을 볼 수 있습니다. 이러한 태그를 사용해서 나중에 pull request를 할 수 있습니다.
+
+드디어, 배포 단계 입니다.
+
+```bash
+yarn release
+```
+
+순서는 다음과 같습니다:
+
+- 애드온 코드를 빌드해서 패키지화 해주세요
+- 버전을 정해주세요
+- 깃허브와 npm에 배포하기 위해 push 해주세요
+- 깃허브에 변경로그를 push해주세요
+
+해냈습니다! 성공적으로 패키지를 npm에 출시하고 첫번째 스토리북 애드온을 배포했습니다. npm을 크롤링 하기 때문에 출시한 애드온에 목록에 나타나는 데는 시간이 좀 걸릴 수 있습니다. 애드온이 목록에서 보이지 않는다면, 목록 레포지토리에 issue를 올려주세요.

--- a/content/create-an-addon/react/ko/conclusion.md
+++ b/content/create-an-addon/react/ko/conclusion.md
@@ -8,7 +8,7 @@ description: '스토리북의 확장과 자동화를 도와주세요'
 
 애드온을 만들어서 커뮤니티가 스토리북을 커스텀하고, 자동화할 수 있도록 도와주세요!
 
-시작은 간단합니다. [애드온 키트](https://github.com/storybookjs/addon-kit)는 애드온을 구축하는 데 필요한 모든 것을 제공합니다. [애드온 API](https://storybook.js.org/docs/react/addons/addons-api)를 사용해서 새로운 기능을 추가하고, 작업흐름을 자동화하고, 즐겨 쓰는 라이브러리와 통합할 수 있습니다. 또한, [애드온 목록](https://storybook.js.org/addons)을 통해 애드온을 수천만명의 개발자와 함께 공유할 수 있습니다.
+시작은 간단합니다. [애드온 키트](https://github.com/storybookjs/addon-kit)는 애드온을 구축하는 데 필요한 모든 것을 제공합니다. [애드온 API](https://storybook.js.org/docs/react/addons/addons-api)를 사용해서 새로운 기능을 추가하고, 작업 흐름(workflow)을 자동화하고, 즐겨 쓰는 라이브러리와 통합할 수 있습니다. 또한, [애드온 목록](https://storybook.js.org/addons)을 통해 애드온을 수천만명의 개발자와 함께 공유할 수 있습니다.
 
 ## 더 알아보기
 

--- a/content/create-an-addon/react/ko/conclusion.md
+++ b/content/create-an-addon/react/ko/conclusion.md
@@ -1,0 +1,23 @@
+---
+title: '결론'
+tocTitle: '결론'
+description: '스토리북의 확장과 자동화를 도와주세요'
+---
+
+축하합니다! 첫번째 스토리북 애드온을 만들어보고 출시도 해보았습니다. 그 과정을 통해 스토리북의 내부 작동방식과 커스텀 하는 방법을 배워봤습니다. 자바스크립트 개발자의 [42%](https://2020.stateofjs.com/en-us/technologies/testing/testing_experience_ranking/)는 이미 스토리북을 사용하고 있습니다. 동적 애드온 생태계가 주된 이유 중 하나입니다.
+
+애드온을 만들어서 커뮤니티가 스토리북을 커스텀하고, 자동화할 수 있도록 도와주세요!
+
+시작은 간단합니다. [애드온 키트](https://github.com/storybookjs/addon-kit)는 애드온을 구축하는 데 필요한 모든 것을 제공합니다. [애드온 API](https://storybook.js.org/docs/react/addons/addons-api)를 사용해서 새로운 기능을 추가하고, 작업흐름을 자동화하고, 즐겨 쓰는 라이브러리와 통합할 수 있습니다. 또한, [애드온 목록](https://storybook.js.org/addons)을 통해 애드온을 수천만명의 개발자와 함께 공유할 수 있습니다.
+
+## 더 알아보기
+
+[애드온 공식문서](https://storybook.js.org/docs/react/addons/introduction)는 더 많은 가이드, 코드 샘플, 지식으로 가득한 레시피를 제공합니다.
+
+저희와 함께 코딩한다면, 레포지토리는 다음과 같아야 합니다:[애드온 레포지토리 예시](http://github.com/chromaui/learnstorybook-addon-code). 이 예시는 [스토리북 애드온 outline](https://github.com/chromaui/storybook-addon-outline)을 기반으로 하고 있습니다.
+
+[스토리북 공식 페이지](https://next--storybookjs.netlify.app/official-storybook/) 를 통해 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [다크 모드](https://github.com/hipstersmoothie/storybook-dark-mode), [다른 모든 공식 애드온](https://github.com/storybookjs/storybook/tree/next/addons)을 참고할 수 있습니다.
+
+여기까지 함께해주셔서 감사합니다. 유용한 블로그와 가이드가 게시될 때 알림을 받으려면 스토리북 이메일 구독 계정을 등록해주세요.
+
+<iframe style="height:400px;width:100%;max-width:800px;margin:0px auto;" src="https://upscri.be/d42fc0?as_embed"></iframe>

--- a/content/create-an-addon/react/ko/decorators.md
+++ b/content/create-an-addon/react/ko/decorators.md
@@ -1,23 +1,16 @@
 ---
-title: 'Decorators'
-tocTitle: 'Decorators'
-description: 'Interacting with the stories'
+title: '데코레이터'
+tocTitle: '데코레이터'
+description: '스토리와의 상호작용'
 commit: '0e7246a'
 ---
 
-Almost there. So far, we created a tool, added it to the toolbar and it even tracks state. We now need to respond to this state and show/hide the outlines.
 
-이제 거의 끝났습니다. 지금까지 우리는 툴을 만들어 툴바에 추가했고,
+이제 거의 끝났습니다. 지금까지 우리는 툴을 만들어 툴바에 추가했고, 이제는 이 state에 대응하여 아웃라인을 표시하고, 숨겨야 합니다.
 
-이제는 이 state에 대응하여 아웃라인을 표시하고, 숨겨야 합니다.
+[데코레이터](https://storybook.js.org/docs/react/writing-stories/decorators)는 스토리를 감싸고 엑스트라 렌더링 기능을 추가합니다. 이번 장에서 글로벌 아웃라인에 대응하고 CSS 인젝션을 처리하는 데코레이터를 만들어 볼 것입니다. 차례로 모든 HTML 요소 주위에 아웃라인을 그려볼 것입니다.
 
-[Decorators](https://storybook.js.org/docs/react/writing-stories/decorators) wrap stories and add-in extra rendering functionality. We are going to create a decorator that responds to the outline global and handles CSS injection. Which in turn, draw outlines around all HTML elements.
-
-[데코레이터](https://storybook.js.org/docs/react/writing-stories/decorators)는 story를 래핑하고 엑스트라 렌더링 기능을 추가합니다. 우리는 글로벌 아웃라인에 대응하고 CSS 인젝션을 처리하는 데코레이터를 만들 겁니다. 이것은 차례로 모든 HTML 엘리먼트 주위에 아웃라인을 그리는 것입니다.
-
-In the previous step we defined the `outlineActive` global, let's wire it up! We can consume globals in a decorator using the `useGlobals` hook.
-
-이전 단계에서 `outlineActive` Global을 규정했고, 정리해 보세요! `useGlobals` 훅 을 사용하여 데코레이터에서 글로벌을 소비할 수 있습니다.
+이전 단계에서 `outlineActive`을 전역으로 정의해봤습니다. 이어서 `useGlobals` 훅을 사용하여 데코레이터에서 전역상태를 사용할 수 있습니다.
 
 ```js:title=src/withGlobals.js
 /* eslint-env browser */
@@ -25,12 +18,12 @@ import { useEffect, useGlobals } from '@storybook/addons';
 
 export const withGlobals = (StoryFn, context) => {
   const [{ outlineActive }, updateGlobals] = useGlobals();
-  // Is the addon being used in the docs panel
+  // 문서 판넬에서 애드온을 사용하는지 여부
   const isInDocs = context.viewMode === 'docs';
 
   useEffect(() => {
-    // Execute your side effect here
-    // For example, to manipulate the contents of the preview
+    // 이 곳에서 사이드 이펙트를 실행하세요.
+    // 예를 들어, 미리보기 콘텐츠를 여기서 다뤄보세요.
     const selectorId = isInDocs ? `#anchor--${context.id} .docs-story` : `root`;
 
     displayToolState(selectorId, { outlineActive, isInDocs });
@@ -60,12 +53,9 @@ ${JSON.stringify(state, null, 2)}
 }
 ```
 
-## Injecting the outline CSS
 ## 아웃라인 CSS 삽입하기
 
-Adding and clearing styles is a side-effect, therefore, we need to wrap that operation in `useEffect`. Which in turn is triggered by the `outlineActive` global. The Kit code comes with an example but, let's update it to handle the outline CSS injection.
-
-스타일 추가 및 클리어는 부작용이기 때문에 이 작업을 `useEffect`에서 wrap해야 합니다. 다음으로 `outlineActive` global에 의해 트리거됩니다. Kit 코드에는 예시가 포함되어 있는데, outline CSS 인젝션을 처리하도록 업데이트 해보세요.
+스타일을 추가하거나 제거하는 것은 사이드 이펙트이기 때문에 이 작업을 `useEffect`에서 함수 안에 감싸줘야 합니다. 다음으로 `outlineActive` 전역에 의해 트리거됩니다. 키드 코드는 예시가 제공되지만, outline CSS 주입을 처리하도록 업데이트 해보겠습니다.
 
 ```js:title=src/withGlobals.js
 /* eslint-env browser */
@@ -76,7 +66,7 @@ import outlineCSS from './outlineCSS';
 
 export const withGlobals = (StoryFn, context) => {
   const [{ outlineActive }, updateGlobals] = useGlobals();
-  // Is the addon being used in the docs panel
+  // 문서 판넬에서 애드온을 사용하는지 여부
   const isInDocs = context.viewMode === 'docs';
 
   const outlineStyles = useMemo(() => {
@@ -104,25 +94,15 @@ export const withGlobals = (StoryFn, context) => {
 };
 ```
 
-Ok, that seems like a big jump. Let’s walk through all the changes.
+좋습니다, 큰 도약을 한 것 같습니다. 모든 변경사항을 살펴보겠습니다.
 
-좋습니다, 큰 도약을 한 것 같습니다. 변경된 것을 보세요.
+애드온은 문서 및 스토리 보기 모드에서 모두 활성화될 수 있습니다. 미리 보기 `iframe`의 실제 DOM 노드는 이 두 모드에서 서로 다릅니다. 실제로, 문서 모드는 한 페이지에 여러 개의 스토리 미리보기를 렌더링합니다. 따라서 스타일이 주입될 DOM 노드에 적합한 셀렉터(selector)를 선택해야 합니다. 또한 CSS는 특정 셀렉터(selector)로 범위를 지정해야 합니다.
 
-The addon can be active in both docs and story view modes. The actual DOM node for the preview `iframe` is different in these two modes. In fact, the docs mode renders multiple story previews on one page. Therefore, we need to pick the appropriate selector for the DOM node where the styles will be injected. Also, the CSS needs to be scoped to that particular selector.
+<div class="aside"> 💡 여기서 <code>useMemo</code> 및 <code>useEffect</code>는 리액트가 아니라 <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a>에서 가져온 것이며 반응하지 않습니다. 왜냐하면 Storybook 미리보기에서 데코레이터 코드가 실행 중이기 때문입니다. 리액트를 이외의 사용자 코드가 로드되는 곳이기 때문에 Storybook은 우리가 사용하는 리액트와 유사한 훅 라이브러리를 구현합니다.</div>
 
-애드온은 문서 및 story 뷰 모드 모두에서 활성화될 수 있습니다. 미리 보기 `iframe`의 실제 DOM 노드는 이 두 모드에서 서로 다릅니다. 실제로, 워드프로세서 모드는 한 페이지에 여러 개의 스토리 프리뷰를 렌더링합니다. 따라서 스타일을 주입할 DOM 노드에 적합한 선택기를 선택해야 합니다. 또한 CSS는 특정 선택기로 범위를 지정할 필요가 있습니다.
+다음으로, DOM에 스타일을 주입할 때, 사용자가 스타일을 끄거나 보기 모드를 전환할 때 스타일을 초기화 할 수 있도록 스타일을 추적해야 합니다.
 
-<div class="aside"> 💡 <code>useMemo</code> and <code>useEffect</code> here come from <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a> and not React. This is because the decorator code is running in the preview part of Storybook. That's where the user's code is loaded which may not contain React. Therefore, to be framework agnostic, Storybook implements a React-like hook library which we can use!</div>
-
-<div class="aside"> 💡 여기서 <code>useMemo</code> 및 <code>useEffect</code>는 <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a>에서 가져온 것이며 반응하지 않습니다. 왜냐하면 스토리북 미리보기 부분에서 데코레이터 코드가 실행 중이기 때문입니다. 데코레이터 코드는 리액트를 포함하지 않을 수 있는 사용자 코드가 로드되는 곳입니다. 따라서 프레임워크에 구애받지 않기 위해 Storybook은 사용할 수 있는 React와 같은 hook 라이브러리를 구현합니다.</div>
-
-Next, as we inject the styles into the DOM, we need to keep track of them to clear them when the user toggles it off or switches the view mode.
-
-다음으로, DOM에 스타일을 주입할 때, 사용자가 스타일을 끄거나 보기 모드를 전환할 때 지울 수 있도록 스타일을 추적해야 합니다.
-
-To manage all this CSS logic, we need a few helpers. These use DOM APIs to inject and remove stylesheets.
-
-이 모든 CSS 로직을 관리하려면 도우미가 필요합니다. DOM API를 사용하여 스타일시트를 주입하고 제거합니다.
+이 모든 CSS 로직을 관리하려면 헬퍼 함수가 필요합니다. 이 함수는 DOM API를 사용하여 스타일시트를 주입하고 제거합니다.
 
 ```js:title=src/helpers.js
 /* eslint-env browser */
@@ -153,12 +133,8 @@ export const addOutlineStyles = (selector, css) => {
 };
 ```
 
-And the outline CSS itself is based on what [Pesticide](https://github.com/mrmrs/pesticide) uses. Grab it from [outlineCSS.js](https://github.com/chromaui/learnstorybook-addon-code/blob/main/src/outlineCSS.js) file.
+그리고 CSS의 outline 자체는 [Pesticide](https://github.com/mrmrs/pesticide)가 사용하는 것을 기반으로 합니다. [outlineCSS.js](https://github.com/chromaui/learnstorybook-addon-code/blob/main/src/outlineCSS.js) 파일에서 가져오세요.
 
-그리고 CSS의 outline 자체는 [Pesticide](https://github.com/mrmrs/pesticide)가 사용하는 것에 기초합니다. [outlineCSS.js](https://github.com/chromaui/learnstorybook-addon-code/blob/main/src/outlineCSS.js) 파일에서 가져오세요.
+이를 통해 UI 요소 주위에 outline을 그릴 수 있습니다.
 
-All together, this enables us to draw outlines around the UI elements.
-
-이를 통해 UI 엘리먼트 주위에 outline을 그릴 수 있습니다.
-
-![toggling the tool toggles the outlines](../../images/outlines.png)
+![도구를 껐다 켰다 하면 아웃라인이 나타납니다](../../images/outlines.png)

--- a/content/create-an-addon/react/ko/introduction.md
+++ b/content/create-an-addon/react/ko/introduction.md
@@ -1,44 +1,43 @@
 ---
-title: '애드온(addons)에 대한 소개'
+title: '애드온에 대한 소개'
 tocTitle: '소개'
 description: '애드온의 구조'
 ---
 
-<div class="aside">본 가이드는 Storybook 애드온을 구축하고자 하는 <b>프로페셔널한 개발자</b>들을 위해 작성되었습니다. 중급 이상의 자바스크립트나 리액트에 대한 경험이 필요합니다. Storybook에 대한 기본 개념 역시 알아야 하는데, 그 예로는 스토리를 쓴다거나 환경설정(config)을 쓰는 방법 등이 있습니다. (<a href="/intro-to-storybook">Intro to Storybook</a> 에서 기본을 가르치고 있습니다).
+<div class="aside">본 가이드는 Storybook 애드온을 구축하고자 하는 <b>전문 개발자</b>들을 위해 작성되었습니다. 자바스크립트나 리액트에 대한 중급 경험을 권장합니다. 또한, Storybook에 대한 기본 개념 역시 알아야 하는데, 그 예로는 스토리를 쓴다거나 환경설정(config)을 쓰는 방법 등이 있습니다. (<a href="/intro-to-storybook">Intro to Storybook</a> 에서 기본사항을 설명하고 있습니다).
 </div>
 
 <br/>
 
-Storybook은 앱 외부의 분리된 공간에서의 UI 컴포넌트 개발을 위한 도구입니다.
-애드온은 워크플로우 부분을 자동화하고 향상하는 것을 도와줍니다. 실제로, Storybook의 중요한 특징들은 애드온과 만들어져 있습니다. 예시로 - [문서 Documentation](https://storybook.js.org/docs/react/writing-docs/introduction), [접근성 테스트 Accessibility testing](https://storybook.js.org/addons/@storybook/addon-a11y) and [상호작용 통제 Interactive controls](https://storybook.js.org/docs/react/essentials/controls) 등이 있습니다.[200여 개의 애드온이](https://storybook.js.org/addons) UI 개발자들의 시간 절약을 돕고 있습니다.
+Storybook은 앱 외부의 분리된 공간에서의 UI 컴포넌트 개발을 위한 도구입니다. 애드온을 사용하면 작업 흐름(workflow)의 일부를 개선하고 자동화할 수 있습니다. 실제로, Storybook의 중요한 특징들은 애드온으로 구현되어 있습니다. 예시로 - [문서](https://storybook.js.org/docs/react/writing-docs/introduction), [접근성 테스트](https://storybook.js.org/addons/@storybook/addon-a11y), [상호작용 통제](https://storybook.js.org/docs/react/essentials/controls) 등이 있습니다.[200여 개의 애드온이](https://storybook.js.org/addons) UI 개발자들의 시간 절약을 돕고 있습니다.
 
 ## 무엇을 만들 것인가?
 
-CSS 레이아웃이 디자인과 맞는지에 대해 확언하는 것은 어려운 일입니다. 눈대중을 사용한 정렬은 미묘할 수 있습니다. 특히나 DOM 엘리먼트가 멀리 떨어져 있거나 이상한 모양을 가지고 있다면 말입니다.
+CSS 레이아웃이 디자인과 일치하는지에 대해 확언하는 것은 어려운 일입니다. 눈대중을 사용한 정렬은 미묘할 수 있습니다. 특히나 DOM 엘리먼트가 멀리 떨어져 있거나 이상한 모양을 가지고 있다면 말입니다.
 
-[아웃라인 애드온](https://storybook.js.org/addons/storybook-addon-outline) 아웃라인 애드온은 CSS를 이용해서 UI 엘리먼트의 아웃라인을 잡는 툴바 버튼을 더하고 있습니다. 이것은 포지셔닝이나 자리 배치에 대한 것들을 한눈에 쉽게 하도록 도와줍니다. 아래 예제를 살펴보세요.
+[아웃라인 애드온](https://storybook.js.org/addons/storybook-addon-outline) 아웃라인 애드온은 CSS를 이용해서 UI 요소의 아웃라인을 잡는 툴바 버튼을 추가합니다. 이를 통해 위치나 자리 배치를 한눈에 쉽게 확인할 수 있습니다. 아래 예제를 살펴보세요.
 
 ![아웃라인 애드온(../../images/outline-addon-hero.gif)
 
-## Addon의 구조
+## 애드온의 구조
 
-애드온은 Storybook으로 가능한 것들을 더욱 확장할 수 있게 도와줍니다. 인터페이스에 있는 것들부터 API까지 모두 말입니다. 이것들이 UI 엘리먼트 개발 워크플로우를 크게 도와줍니다.
+애드온은 Storybook으로 가능한 것들을 더욱 확장할 수 있게 도와줍니다. 인터페이스에 있는 것들부터 API까지 모두 말입니다. 이것들이 UI 요소 개발 작업 흐름(workflow)을 크게 도와줍니다.
 
 애드온은 두 가지의 넓은 카테고리로 나뉩니다 - 
 
-- **UI-based:** 인터페이스를 커스터마이징하고, 반복적인 일이나 포맷, 추가적인 정보 배치에 단축키를 더합니다. 예를 들면 문서화, 접근성 테스트, 상호작용통제(interactive controls), 그리고 디자인 미리보기 등이 있습니다.
+- **UI 기반의 애드온:** 인터페이스를 커스터마이징하고, 반복적인 일이나 포맷, 추가적인 정보 배치에 단축키를 더합니다. 예를 들면 문서화, 접근성 테스트, 상호작용통제(interactive controls), 그리고 디자인 미리보기 등이 있습니다.
 
-- **Presets:** Storybook에 자동적으로 적용된 환경설정의 모음입니다. 이것들은 주로 Storybook을 다른 특정 기술과 함께 사용하도록 빠르게 짝지어줍니다. 예를 들면, preset-create-react-app, preset-nuxt 그리고 preset-scss 이 있습니다.
+- **프리셋:** Storybook에 자동적으로 적용되는 환경설정의 모음입니다. 이것들은 주로 Storybook을 다른 특정 기술과 함께 사용하도록 빠르게 짝지어줍니다. 예를 들면, preset-create-react-app, preset-nuxt 그리고 preset-scss 이 있습니다.
 
-## UI 기반의(UI-based) 애드온
+## UI 기반의 애드온
 
-애드온은 세가지 타입의 인터페이스 엘리먼트를 만들 수 있습니다 - 
+애드온은 세가지 타입의 인터페이스 요소를 만들 수 있습니다 - 
 
 1. 툴바에 툴을 더할 수 있습니다. [그리드와 배경](https://storybook.js.org/docs/react/essentials/backgrounds) 등의 도구가 있습니다.
 
 ![](../../images/toolbar.png)
 
-2. [액션 애드온](https://storybook.js.org/docs/react/essentials/actions) 을 닮은 애드온은 판넬을 만들 수 있습니다. 현황 일지를 배치할 수 있습니다.
+2. [액션 애드온](https://storybook.js.org/docs/react/essentials/actions)을 닮은 애드온은 판넬을 만들 수 있습니다. 현황 일지를 배치할 수 있습니다.
 
 ![](../../images/panel.png)
 
@@ -48,11 +47,11 @@ CSS 레이아웃이 디자인과 맞는지에 대해 확언하는 것은 어려�
 
 애드온으로 많은 것을 할 수 있다는 것은 확실해보입니다. 그래서 대체 애드온은 뭘 하는 걸까요?
 
-아웃라인 애드온은 개발자로 하여금 스토리에 있는 각 엘리먼트의 아웃라인을 그릴 수 있는 툴바의 버튼을 클릭하게 도와줍니다. 버튼을 한 번 더 누르면, 이제 아웃라인들은 지워집니다.
+아웃라인 애드온은 개발자로 하여금 스토리에 있는 각 요소의 아웃라인을 그릴 수 있는 툴바의 버튼을 클릭하게 도와줍니다. 버튼을 한 번 더 누르면, 모든 아웃라인들은 지워집니다.
 
 애드온 코드는 앞으로 우리가 다룰 챕터에서 네 가지 부분으로 나누어 설명합니다 - 
 
-- **애드온 UI** 툴바에 “tool” 버튼을 만듭니다. 이것이 사용자가 클릭하는 버튼입니다.
-- **등록** 스토리북에 addon을 등록합니다.
+- **애드온 UI** 툴바에 “툴” 버튼을 만듭니다. 이것이 사용자가 클릭하는 버튼입니다.
+- **등록** 스토리북에 애드온을 등록합니다.
 - **State 관리** 툴의 토글 상태를 확인합니다. 이것으로 아웃라인을 시각적으로 보이게 하느냐 마느냐를 통제할 수 있습니다.
 - **데코레이터** CSS를 미리보기 iframe에서 주입하여 아웃라인을 그립니다.

--- a/content/create-an-addon/react/ko/preset.md
+++ b/content/create-an-addon/react/ko/preset.md
@@ -1,7 +1,7 @@
 ---
 title: '프리셋'
 tocTitle: '프리셋'
-description: '모든 스토리에 윤곽을 보여줄 수 있습니다.'
+description: '모든 스토리에 아웃라인을 보여줄 수 있습니다.'
 ---
 
 이제 데코레이터 부분이 끝났으니, 모든 스토리를 감싸기 위해 preset 기능을 사용해봅시다. 
@@ -23,7 +23,7 @@ export const decorators = [withGlobals];
 
 <div class="aside">💡 애드온 키트의 <code>withRoundTrip</code> 데코레이터는 애드온과 스토리 간 양방향 소통을 위한 예시입니다. 하지만 애드온에 꼭 필요한 것은 아니며 삭제할 수 있습니다.</div>
 
-![도구를 껐다 켰다 하면 윤곽선이 나타납니다](../../images/toggle.gif)
+![도구를 껐다 켰다 하면 아웃라인이 나타납니다](../../images/toggle.gif)
 
 ## 최상위 단계 프리셋
 

--- a/content/create-an-addon/react/ko/preset.md
+++ b/content/create-an-addon/react/ko/preset.md
@@ -1,0 +1,51 @@
+---
+title: '프리셋'
+tocTitle: '프리셋'
+description: '모든 스토리에 윤곽을 보여줄 수 있습니다.'
+---
+
+이제 데코레이터 부분이 끝났으니, 모든 스토리를 감싸기 위해 preset 기능을 사용해봅시다. 
+
+프리셋을 사용하면 다양한 스토리북의 환경설정값을 결합할 수 있고, 한번에 적용할 수 있습니다. 일부 addon은 단순히 스토리북의 구성만 담당하고, UI가 존재하지 않습니다. 예를 들어, <a href="https://www.npmjs.com/package/@storybook/preset-create-react-app">preset-create-react-app</a>와 <a href="https://www.npmjs.com/package/storybook-preset-nuxt">preset-nuxt</a>가 그렇습니다. 이러한 요소를 <a href="https://storybook.js.org/docs/react/addons/writing-presets">프리셋 애드온</a>이라고 합니다.
+
+프리셋은 두 가지로 분류할 수 있습니다:
+
+1. addon 등록을 위한 `manager.js` 
+2. 글로벌 데코레이터를 명시하기 위한 `preview.js`
+
+모든 스토리를 자동으로 감싸주는 `withGlobals` 데코레이터를 사용해 디자인 미리보기를 업데이트 해주세요.
+
+```js:title=src/preset/preview.js
+import { withGlobals } from '../withGlobals';
+
+export const decorators = [withGlobals];
+```
+
+<div class="aside">💡 애드온 키트의 <code>withRoundTrip</code> 데코레이터는 애드온과 스토리 간 양방향 소통을 위한 예시입니다. 하지만 애드온에 꼭 필요한 것은 아니며 삭제할 수 있습니다.</div>
+
+![도구를 껐다 켰다 하면 윤곽선이 나타납니다](../../images/toggle.gif)
+
+## 최상위 단계 프리셋
+
+목록에 애드온을 추가하기 앞서, 짚고 넘어갈만한 항목이 하나 있습니다. 각각의 스토리북의 애드온에는 사용자의 추가 환경설정 없이 애드온을 등록하기 위해 최상위 단계 프리셋이 포함되어 있어야 합니다. 운좋게도 이것은 우리가 [셋업 (Set up)장](/create-an-addon/react/en/getting-started/)에서 레포지토리를 클론할 때 설정되어 있습니다. 최상위 폴더에서 `preset.js`파일을 열면 다음과 같은 내용을 확인할 수 있습니다:
+
+```js:title=preview.js
+function config(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/preview")];
+}
+
+function managerEntries(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/manager")];
+}
+
+module.exports = {
+  managerEntries,
+  config,
+};
+```
+
+<div class="aside">
+ 💡 프리셋에 대해 더 자세히 알고 싶다면 <a href="https://storybook.js.org/docs/react/addons/writing-presets#manager-entries">스토리북 공식문서</a>를 읽어보세요.
+</div>
+
+성공했습니다! 이제 로컬저장소의 스토리북에 완전한 기능을 하는 애드온이 생겼습니다. 마지막 장에서는, 목록에 애드온을 나열하는 법을 배워볼 것입니다. 그렇게 하면 팀과 스토리북 커뮤니티와 공유하게 됩니다.

--- a/content/create-an-addon/react/ko/register-addon.md
+++ b/content/create-an-addon/react/ko/register-addon.md
@@ -1,12 +1,12 @@
 ---
 title: '애드온 등록하기'
 description: '애드온 UI를 만들고 Storybook 안에 등록하기'
-commit: '5db9bc9'
+commit: ''
 ---
 
-이 파일 `src/Tool.js` 에서 시작합시다. 이곳이 아웃라인 툴을 위한 UI 코드가 있을 곳입니다. 이 import를 [@storybook/components](https://www.npmjs.com/package/@storybook/components) 확인하세요. Storybook의 컴포넌트 라이브러리이며, 리액트와 이모션으로 만들어져 있습니다. Storybook을 만드는 자체에 사용되었기도 합니다 ([데모](https://next--storybookjs.netlify.app/official-storybook/)). 우리도 애드온을 만드는 데에 사용할 수 있습니다.
+`src/Tool.js`파일에서 시작해봅시다. 여기에 아웃라인 툴의 UI 코드가 위치합니다. [@storybook/components](https://www.npmjs.com/package/@storybook/components) 경로에서 import 하세요. 리액트와 이모션으로 구축된 Storybook의 컴포넌트 라이브러리입니다. Storybook 자체([데모](https://next--storybookjs.netlify.app/official-storybook/))를 구축하는데 사용하고, 애드온을 만드는 데에 사용할 수 있습니다.
 
-이번에는 `Icons` 와 `IconButton` 컴포넌트를 사용하여 아웃라인 선택자 툴을 만들겠습니다. 코드를 수정하고, `outline` 아이콘을 사용하여 적당한 제목을 줍니다.
+이번에는 `Icons` 와 `IconButton` 컴포넌트를 사용하여 아웃라인 셀렉터(selector) 툴을 만들겠습니다. `outline` 아이콘을 사용하여 적절한 이름을 붙여 코드를 수정해보세요.
 
 ```js:title=src/Tool.js
 import React, { useCallback } from 'react';
@@ -39,8 +39,7 @@ export const Tool = () => {
 ```
 
 manger 파일로 이동해서, 애드온을 Storybook과 함께 고유 아이디로 `ADDON_ID` 등록합니다. 
-툴 역시도 고유한 아이디와 함께 등록합니다. `storybook/addon-name`과 같은 이름을 추천드립니다. 애드온 키트 역시 탭과 패널 예시를 포함하고 있습니다. 아웃라인 애드온이 툴만을 사용하기 때문에, 나머지는 삭제합니다.
-
+툴 역시도 고유한 아이디와 함께 등록합니다. `storybook/addon-name`과 같은 이름을 권장합니다. 애드온 키트는 탭과 판넬 예시도 포함하고 있습니다. 아웃라인 애드온은 툴만을 사용하기 때문에, 나머지는 삭제해도 됩니다.
 
 
 ```js:title=src/preset/manager.js
@@ -49,9 +48,9 @@ import { addons, types } from '@storybook/addons';
 import { ADDON_ID, TOOL_ID } from '../constants';
 import { Tool } from '../Tool';
 
-// Register the addon
+// 애드온을 등록하세요
 addons.register(ADDON_ID, () => {
-  // Register the tool
+  // 툴을 등록하세요
   addons.add(TOOL_ID, {
     type: types.TOOL,
     title: 'My addon',
@@ -61,8 +60,8 @@ addons.register(ADDON_ID, () => {
 });
 ```
 
-프로퍼티의 짝을 확인하세요. 어떤 보기 모드에서 애드온이 활성화될지 통제할 수 있게 해줍니다. 이러한 경우에, 애드온은 스토리와 다큐먼트 모드에서 활성화될 것입니다.
+match 프로퍼티를 확인하세요. 애드온을 활성화할 보기모드를 제어할 수 있습니다. 이럴 경우, 애드온은 스토리와 문서 모드에서 활성화될 것입니다.
 
-지금 시점에서 당신은 아웃라인 선택자 툴을 툴바에서 볼 수 있어야 합니다 🎉
+이제 툴바에서 아웃라인 셀렉터(selector) 툴을 볼 수 있을겁니다.🎉
 
 ![Enable the outline tool](../../images/outline-tool.png)

--- a/content/create-an-addon/react/ko/setup.md
+++ b/content/create-an-addon/react/ko/setup.md
@@ -1,38 +1,36 @@
 ---
-title: '셋업(Setup)'
+title: '설치'
 description: '애드온 키트로 시작하기'
-commit: 'd3b6651'
+commit: ''
 ---
 
 ![](../../images/addon-kit-demo.gif)
 
-우리는 [애드온 키트](https://github.com/storybookjs/addon-kit) 를 사용하여 프로젝트를 부트스트랩 합니다. 
-당신이 Storybook 애드온을 만들기 위해 필요한 모든 것을 제공합니다:
+우리는 [애드온 키트](https://github.com/storybookjs/addon-kit) 를 사용하여 프로젝트를 부트스트랩 합니다. Storybook 애드온을 구축하는 데 필요한 모든 것을 제공합니다.
 
 - 📝 개발 모드에서 실시간 편집
 - ⚛️ UI를 위한 React/JSX 지원
-- 📦 트랜스파일링과 번들링을 [Babel]과 함께(http://babeljs.io/)
+- 📦 [Babel](http://babeljs.io/)을 사용한 트랜스파일링 및 번들링
 - 🏷 플러그인 메타데이터
-- 🚢 릴리즈 관리를 [Auto]와 함께(https://github.com/intuit/auto)
+- 🚢 [Auto](https://github.com/intuit/auto)를 사용하는 배포 관리 
 
-시작하기에 앞서, [애드온 키트 레포지토리](https://github.com/storybookjs/addon-kit)에서 **use thie template** 버튼을 클릭하세요.
-새로운 레포지토리를 애드온 키트 코드와 함께 생성해줄 것입니다.
+시작하기에 앞서, [애드온 키트 레포지토리](https://github.com/storybookjs/addon-kit)에서 **use thie template** 버튼을 클릭하세요. 그러면 모든 애드온 키트가 포함된 새로운 레포지토리가 생성됩니다.
 
 ![](../../images/addon-kit.png)
 
-다음으로, 레포지토리를 클론하고 dependencies를 설치합니다.
+다음으로, 레포지토리를 클론하고 의존성(dependency)을 설치합니다.
 
 ```bash
 yarn
 ```
 
-애드온 키트는 기본으로 타입스크립트를 사용합니다. 어쨌거나, 우리는 eject command를 사용해서 보일러플레이트 코드를 자바스크립트로 바꿀 거에요. 이 튜토리얼의 목적을 위해서요.
+애드온 키트는 기본으로 타입스크립트를 사용합니다. 하지만 튜토리얼의 목적을 위해 eject 명령어를 사용해서 보일러플레이트 코드를 자바스크립트로 바꿔주세요.
 
 ```bash
 yarn eject-ts
 ```
 
-이 명령어는 모든 코드를 자바스크립트로 변형해줄 겁니다. 파괴적일 수 있는 과정이라, 이 명령어를 다른 어느 코드 작성을 시작하기전에 먼저 실행하기를 추천합니다.
+이 명령어는 모든 코드를 자바스크립트로 변환해줍니다. 파괴적일 수 있는 과정이라, 다른 어느 코드를 작성 하기전에 이 명령어를 먼저 실행하는 것이 좋습니다.
 
 마지막으로, 개발 모드를 시작합니다. Storybook을 시작하고 Babel을 보기 모드에서 볼 수 있습니다.
 
@@ -40,4 +38,4 @@ yarn eject-ts
 yarn start
 ```
 
-애드온 코드는 'src' 디렉토리에 위치하고 있습니다. 포함된 보일러플레이트 코드는 세개의 UI 패러다임과 다른 개념들, 예를 들어 상태 관리나 스토리에 반응하기 등을 보여주고 있습니다. 다음 섹션에서 이것들을 세세하게 다룰 것입니다.
+애드온 코드는 'src' 폴더에 있습니다. 포함된 보일러플레이트 코드는 세개의 UI 패러다임과 다른 개념들, 예를 들어 상태 관리나 스토리에 반응하기 등을 보여주고 있습니다. 다음 장에서는 이에 대해 더 자세히 살펴볼 것입니다.

--- a/content/create-an-addon/react/ko/track-state.md
+++ b/content/create-an-addon/react/ko/track-state.md
@@ -5,28 +5,28 @@ description: '애드온의 state를 Manager와 Preview로 관리하기'
 commit: 'ffd9ccb'
 ---
 
-리액트는 [hooks](https://reactjs.org/docs/hooks-state.html#gatsby-focus-wrapper) 로 만들어졌고 그 예로는 state를 관리하기 위한 `useState`이 있습니다. 보통은 이것으로 충분합니다만, 이 경우에는 조금 복잡합니다. 잠시 스토리북이 어떻게 구축되어 있는지를 이야기 해보겠습니다.
+리액트는 state를 관리하기 위해 `useState` 같은 내장된 [훅](https://reactjs.org/docs/hooks-state.html#gatsby-focus-wrapper)이 있습니다. 일반적으로 이것으로 충분합니다만, 이 경우에는 상황이 조금 더 복잡합니다. Storybook이 어떻게 구성되어 있는지를 이야기 해보겠습니다.
 
-## 스토리북 구조의 기초
+## Storybook 구조의 기초
 
 ![](../../images/manager-preview.jpg)
 
-겉으로 보기에는 스토리북은 통일화된 유저 인터페이스(UI)를 보여줍니다. 그러나 안에서는, 두 세그먼트로 나뉘어져, **커뮤니케이션 채널을 통해서 이야기를 나눕니다:**
+표면적으로 Storybook은 통합된 UI를 보여줍니다. 그러나 내부적으로는, **커뮤니케이션 채널을 통해 소통하는** 두 가지의 영역으로 나뉩니다.
 
-- **A Manager:** 스토리북의 검색, 네비게이션, 툴바, 애드온이 렌더링되는 UI 입니다.
-- **Preview:** 스토리들이 렌더링되는 아이프레임.
+- **A Manager:** Storybook의 검색, 네비게이션, 툴바, 애드온이 렌더링되는 UI 입니다.
+- **Preview:** 스토리들이 렌더링되는 iframe 입니다.
 
-토클 state를 추적해야하고 **또** 그 state를 Manager와 Preview에 모두 공유해야합니다. 그리하여, `useState` 대신 `@storybook/api`의 `useGlobals`를 사용하겠습니다.
+토클 state를 추적해야 하며 **또한** Manager와 Preview 모두에서 해당 state를 공유해야 합니다. 그리하여, `useState` 대신 `@storybook/api`의 `useGlobals`를 사용하겠습니다.
 
 ## 전역 state 추적하기
 
-[Globals](https://storybook.js.org/docs/react/essentials/toolbars-and-globals/#globals) 는 “전역” (스토리에 국한된 것이 아닌) 컨텍스트를 스토리북에서 가집니다. 다른 스토리와 애드온과 데코레이터 사이에서 정보를 공유하기 편한 방법들입니다. `useGlobals` 훅은 이 전역 컨텍스트에 대한 접근을 당신이 만드는 툴 안에서 허락합니다.
+[전역](https://storybook.js.org/docs/react/essentials/toolbars-and-globals/#globals)은 Storybook에서 “전역” (스토리에 국한된 것이 아닌) 컨텍스트를 말합니다. 다양한 스토리와 애드온, 데코레이터 간 정보를 공유하기 편한 방법입니다. `useGlobals` 훅은 구축하고 있는 툴 내에서 전역 컨텍스트에 대한 접근할 수 있게 해줍니다.
 
-<div class="aside">다음의 <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a> 에서 API와 관련된 애드온들을 확인하세요.</div>
+<div class="aside">더 많은 애드온 관련 API는 <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a>를 통해 확인하세요.</div>
 
-애드온 키트는 `Tool`을 미리 설정하여 globals를 사용합니다. 전역을 재정의하여 더 정확하게 이것이 무엇을 하는지 반영해봅시다. `toggleOutline` 기능은 사용자로 하여금 아웃라인 애드온을 키고 끄게 토글하는 것을 허용합니다. 👉🏽🔘
+애드온 키트는 전역을 사용하도록 `툴`을 사전에 설정합니다. 전역이 하는 역할을 보다 더 정확하게 반영하기 위해 전역의 이름을 변경해보겠습니다. `toggleOutline` 기능을 사용하면 사용자가 아웃라인 애드온을 켰다 껐다 할 수 있습니다. 👉🏽🔘
 
-![The tool track toggle state](../../images/track-state.gif)
+![토글 state를 추적하기 위한 툴](../../images/track-state.gif)
 
 ```diff:title=src/Tool.jsf
 import React, { useCallback } from 'react';


### PR DESCRIPTION
- 기존에 장키님 부분 번역이 안 되었던 부분 1차 번역 추가 (preset, add-to-catalog, conclusion)
- 키워드 변경 및 어투 변경
  - 도우미 -> 헬퍼 함수
  - 선택기 -> 셀렉터(selector)
  - 워크플로우 -> 작업 흐름(workflow)
  - 짝 -> match (고유한 property 이름이여서)
  

